### PR TITLE
Output in make.conf style

### DIFF
--- a/src/arm.c
+++ b/src/arm.c
@@ -133,7 +133,7 @@ void print_arm()
 {
 	unsigned long hwcap = 0, hwcap2 = 0, subarch = 0;
 	struct utsname uname_res;
-	int i, j;
+	int i, j, printed;
 
 	hwcap = getauxval(AT_HWCAP);
 #ifdef AT_HWCAP2
@@ -157,7 +157,7 @@ void print_arm()
 		}
 	}
 
-	fputs("CPU_FLAGS_ARM:", stdout);
+	fputs("CPU_FLAGS_ARM=\"", stdout);
 
 	for (i = 0; flags[i].name; ++i)
 	{
@@ -198,15 +198,17 @@ void print_arm()
 
 			if (match)
 			{
-				fputc(' ', stdout);
+				if (printed)
+					fputc(' ', stdout);
 				fputs(flags[i].name, stdout);
+				printed = 1;
 
 				break;
 			}
 		}
 	}
 
-	fputs("\n", stdout);
+	fputs("\"\n", stdout);
 }
 
 #endif /*CPUID_ARM*/

--- a/src/x86.c
+++ b/src/x86.c
@@ -140,7 +140,7 @@ void print_x86()
 	int got_intel, got_intel_sub0, got_amd, got_centaur;
 
 	const char* last = "";
-	int i, j;
+	int i, j, printed = 0;
 
 	/* Intel */
 	got_intel = run_cpuid(0x00000001, 0, 0, &intel_ecx, &intel_edx);
@@ -151,7 +151,7 @@ void print_x86()
 	/* Centaur (VIA) */
 	got_centaur = run_cpuid(0xC0000001, 0, 0, 0, &centaur_edx);
 
-	fputs("CPU_FLAGS_X86:", stdout);
+	fputs("CPU_FLAGS_X86=\"", stdout);
 
 	for (i = 0; flags[i].name; ++i)
 	{
@@ -207,17 +207,19 @@ void print_x86()
 			{
 				if (strcmp(last, flags[i].name))
 				{
-					fputc(' ', stdout);
+					if (printed)
+						fputc(' ', stdout);
 					fputs(flags[i].name, stdout);
 
 					last = flags[i].name;
+					printed = 1;
 				}
 				break;
 			}
 		}
 	}
 
-	fputs("\n", stdout);
+	fputs("\"\n", stdout);
 }
 
 #endif /*CPUID_X86*/


### PR DESCRIPTION
This tool used to print a line that the user could just redirect to `make.conf`, like the example in https://wiki.gentoo.org/wiki//etc/portage/make.conf#CPU_FLAGS_X86. Can we go back to that style? It makes it easier to automatically deploy Gentoo.