### PR TITLE
Support different output formats

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,8 @@ bin_PROGRAMS = cpuid2cpuflags
 
 cpuid2cpuflags_SOURCES = \
 	src/main.c \
+	src/output.h \
+	src/output.c \
 	src/platforms.h \
 	src/arm.c \
 	src/x86.c

--- a/README
+++ b/README
@@ -30,6 +30,20 @@ generate/update it automatically, you can use a dedicated file:
   $ echo "*/* $(cpuid2cpuflags)" > /etc/portage/package.use/00cpuflags
 
 
+Building
+~~~~~
+
+These are the steps necessary to build the ./cpuid2cpuflags program:
+
+  $ aclocal
+  $ autoconf
+  $ autoheader
+  $ mkdir -p build-aux
+  $ automake --add-missing
+  $ ./configure
+  $ make
+
+
 Implementation details
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README
+++ b/README
@@ -30,6 +30,10 @@ generate/update it automatically, you can use a dedicated file:
   $ echo "*/* $(cpuid2cpuflags)" > /etc/portage/package.use/00cpuflags
 
 Additional output formats are supported through the --format option.
+For instance, the "make" format is compatible with Portage's make.conf:
+
+  $ cpuid2cpuflags --format make >> /etc/portage/make.conf
+
 
 Building
 ~~~~~

--- a/README
+++ b/README
@@ -22,7 +22,7 @@ The flag definitions match the flags described in Gentoo profiles/desc
 at the time of program release. If additional flags are introduced
 in the future, they will be added in a future program release.
 
-The output format is compatible both with Portage (package.use)
+The default output format is compatible both with Portage (package.use)
 and Paludis (use.conf/options.conf). If you find it useful to
 generate/update it automatically, you can use a dedicated file:
 

--- a/README
+++ b/README
@@ -29,6 +29,7 @@ generate/update it automatically, you can use a dedicated file:
   $ mkdir /etc/portage/package.use   # if not used yet
   $ echo "*/* $(cpuid2cpuflags)" > /etc/portage/package.use/00cpuflags
 
+Additional output formats are supported through the --format option.
 
 Building
 ~~~~~

--- a/README
+++ b/README
@@ -40,13 +40,9 @@ Building
 
 These are the steps necessary to build the ./cpuid2cpuflags program:
 
-  $ aclocal
-  $ autoconf
-  $ autoheader
-  $ mkdir -p build-aux
-  $ automake --add-missing
-  $ ./configure
-  $ make
+  $ autoreconf -vi
+  $ ./configure -C
+  $ make -j
 
 
 Implementation details

--- a/src/arm.c
+++ b/src/arm.c
@@ -7,6 +7,7 @@
 #	include "config.h"
 #endif
 #include "platforms.h"
+#include "output.h"
 
 #ifdef CPUID_ARM
 
@@ -180,7 +181,7 @@ int print_arm()
 		return 1;
 	}
 
-	fputs("CPU_FLAGS_ARM:", stdout);
+	output_prefix("CPU_FLAGS_ARM", stdout);
 
 	for (i = 0; flags[i].name; ++i)
 	{
@@ -223,15 +224,14 @@ int print_arm()
 
 			if (match)
 			{
-				fputc(' ', stdout);
-				fputs(flags[i].name, stdout);
+				output_flag(flags[i].name, stdout);
 
 				break;
 			}
 		}
 	}
 
-	fputs("\n", stdout);
+	output_suffix(stdout);
 	return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -34,7 +34,8 @@ const char* usage = "Usage: %s [options]\n"
 	"\n"
 	"FORMAT:\n"
 	"  use                      compatible with Paludis (use.conf/options.conf)\n"
-	"                           and Portage (package.use). This is the default.\n";
+	"                           and Portage (package.use). This is the default.\n"
+	"  make                     compatible with Portage (make.conf)\n";
 
 int main(int argc, char* argv[])
 {
@@ -53,6 +54,8 @@ int main(int argc, char* argv[])
 			case 'f':
 				if(strcmp(optarg, "use") == 0) {
 					output_set(PACKAGEUSE);
+				} else if(strcmp(optarg, "make") == 0) {
+					output_set(MAKECONF);
 				} else {
 					fprintf(stderr, "%s: unknown FORMAT value '%s'\n", argv[0], optarg);
 					fprintf(stderr, usage, argv[0]);

--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,8 @@ const char* usage = "Usage: %s [options]\n"
 	"FORMAT:\n"
 	"  use                      compatible with Paludis (use.conf/options.conf)\n"
 	"                           and Portage (package.use). This is the default.\n"
-	"  make                     compatible with Portage (make.conf)\n";
+	"  make                     compatible with Portage (make.conf)\n"
+	"  plain                    space-separated list of flags\n";
 
 int main(int argc, char* argv[])
 {
@@ -56,6 +57,8 @@ int main(int argc, char* argv[])
 					output_set(PACKAGEUSE);
 				} else if(strcmp(optarg, "make") == 0) {
 					output_set(MAKECONF);
+				} else if(strcmp(optarg, "plain") == 0) {
+					output_set(PLAIN);
 				} else {
 					fprintf(stderr, "%s: unknown FORMAT value '%s'\n", argv[0], optarg);
 					fprintf(stderr, usage, argv[0]);

--- a/src/main.c
+++ b/src/main.c
@@ -6,10 +6,12 @@
 #ifdef HAVE_CONFIG_H
 #	include "config.h"
 #endif
+#include "output.h"
 #include "platforms.h"
 
 #include <getopt.h>
 #include <stdio.h>
+#include <string.h>
 
 /* x86.c */
 int print_x86();
@@ -19,6 +21,7 @@ int print_arm();
 struct option long_options[] = {
 	{ "help", no_argument, 0, 'h' },
 	{ "version", no_argument, 0, 'V' },
+	{ "format", required_argument, 0, 'f' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -26,13 +29,18 @@ const char* usage = "Usage: %s [options]\n"
 	"\n"
 	"Options:\n"
 	"  -h, --help               print this help message\n"
-	"  -V, --version            print program version\n";
+	"  -V, --version            print program version\n"
+	"  -f, --format=FORMAT      change program output format\n"
+	"\n"
+	"FORMAT:\n"
+	"  use                      compatible with Paludis (use.conf/options.conf)\n"
+	"                           and Portage (package.use). This is the default.\n";
 
 int main(int argc, char* argv[])
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hV", long_options, 0)) != -1)
+	while ((opt = getopt_long(argc, argv, "hVf:", long_options, 0)) != -1)
 	{
 		switch (opt)
 		{
@@ -42,6 +50,15 @@ int main(int argc, char* argv[])
 			case 'V':
 				puts(PACKAGE_STRING);
 				return 0;
+			case 'f':
+				if(strcmp(optarg, "use") == 0) {
+					output_set(PACKAGEUSE);
+				} else {
+					fprintf(stderr, "%s: unknown FORMAT value '%s'\n", argv[0], optarg);
+					fprintf(stderr, usage, argv[0]);
+					return 1;
+				}
+				break;
 			case '?':
 				fprintf(stderr, usage, argv[0]);
 				return 1;

--- a/src/output.c
+++ b/src/output.c
@@ -12,8 +12,13 @@
 /* default output format */
 static enum output_format current_format = PACKAGEUSE;
 
+static const char *ERROR_UNKOWN_FORMAT = "Internal error: unkown output format";
+
+static int flag_count = 0;
+
 void output_set(enum output_format f) {
 	current_format = f;
+	flag_count = 0;
 }
 
 void output_prefix(const char *var_name, FILE *file) {
@@ -22,16 +27,34 @@ void output_prefix(const char *var_name, FILE *file) {
 			fputs(var_name, file);
 			fputs(":", file);
 			break;
+		case MAKECONF:
+			fputs(var_name, file);
+			fputs("=\"", file);
+			break;
 		default:
+			perror(ERROR_UNKOWN_FORMAT);
 			break;
 	}
 }
 
 void output_flag(const char *flag, FILE *file) {
-	fputc(' ', file);
+	if(flag_count > 0 || current_format == PACKAGEUSE) {
+		fputc(' ', file);
+	}
 	fputs(flag, file);
+	flag_count++;
 }
 
 void output_suffix(FILE *file) {
-	fputs("\n", file);
+	switch(current_format) {
+		case PACKAGEUSE:
+			fputs("\n", file);
+			break;
+		case MAKECONF:
+			fputs("\"\n", file);
+			break;
+		default:
+			perror(ERROR_UNKOWN_FORMAT);
+			break;
+	}
 }

--- a/src/output.c
+++ b/src/output.c
@@ -31,6 +31,8 @@ void output_prefix(const char *var_name, FILE *file) {
 			fputs(var_name, file);
 			fputs("=\"", file);
 			break;
+		case PLAIN:
+			break;
 		default:
 			perror(ERROR_UNKOWN_FORMAT);
 			break;
@@ -47,6 +49,7 @@ void output_flag(const char *flag, FILE *file) {
 
 void output_suffix(FILE *file) {
 	switch(current_format) {
+		case PLAIN:
 		case PACKAGEUSE:
 			fputs("\n", file);
 			break;

--- a/src/output.c
+++ b/src/output.c
@@ -1,0 +1,37 @@
+/* output.c
+ * (c) 2018 Nuno Silva
+ *
+ * cpuid2cpuflags
+ * (c) 2015-2017 Michał Górny
+ * 2-clause BSD licensed
+ */
+#include "output.h"
+#include <stdio.h>
+
+
+/* default output format */
+static enum output_format current_format = PACKAGEUSE;
+
+void output_set(enum output_format f) {
+	current_format = f;
+}
+
+void output_prefix(const char *var_name, FILE *file) {
+	switch(current_format) {
+		case PACKAGEUSE:
+			fputs(var_name, file);
+			fputs(":", file);
+			break;
+		default:
+			break;
+	}
+}
+
+void output_flag(const char *flag, FILE *file) {
+	fputc(' ', file);
+	fputs(flag, file);
+}
+
+void output_suffix(FILE *file) {
+	fputs("\n", file);
+}

--- a/src/output.h
+++ b/src/output.h
@@ -1,0 +1,18 @@
+/* output.h
+ * (c) 2018 Nuno Silva
+ *
+ * cpuid2cpuflags
+ * (c) 2015-2017 Michał Górny
+ * 2-clause BSD licensed
+ */
+
+#include <stdio.h>
+
+enum output_format {
+	PACKAGEUSE
+};
+
+void output_set(enum output_format f);
+void output_prefix(const char *var_name, FILE *file);
+void output_flag(const char *flag, FILE *file);
+void output_suffix(FILE *file);

--- a/src/output.h
+++ b/src/output.h
@@ -9,7 +9,7 @@
 #include <stdio.h>
 
 enum output_format {
-	PACKAGEUSE, MAKECONF
+	PACKAGEUSE, MAKECONF, PLAIN
 };
 
 void output_set(enum output_format f);

--- a/src/output.h
+++ b/src/output.h
@@ -9,7 +9,7 @@
 #include <stdio.h>
 
 enum output_format {
-	PACKAGEUSE
+	PACKAGEUSE, MAKECONF
 };
 
 void output_set(enum output_format f);

--- a/src/x86.c
+++ b/src/x86.c
@@ -7,6 +7,7 @@
 #	include "config.h"
 #endif
 #include "platforms.h"
+#include "output.h"
 
 #ifdef CPUID_X86
 
@@ -148,7 +149,7 @@ int print_x86()
 	/* Centaur (VIA) */
 	got_centaur = run_cpuid(0xC0000001, 0, 0, 0, &centaur_edx);
 
-	fputs("CPU_FLAGS_X86:", stdout);
+	output_prefix("CPU_FLAGS_X86", stdout);
 
 	for (i = 0; flags[i].name; ++i)
 	{
@@ -204,8 +205,7 @@ int print_x86()
 			{
 				if (strcmp(last, flags[i].name))
 				{
-					fputc(' ', stdout);
-					fputs(flags[i].name, stdout);
+					output_flag(flags[i].name, stdout);
 
 					last = flags[i].name;
 				}
@@ -214,7 +214,7 @@ int print_x86()
 		}
 	}
 
-	fputs("\n", stdout);
+	output_suffix(stdout);
 	return 0;
 }
 


### PR DESCRIPTION
* Added a --format option which allows changing the output format of the program. It currently supports package.use (default), make.conf and a "plain" formats:
```
$ ./cpuid2cpuflags
CPU_FLAGS_X86: aes avx f16c mmx mmxext pclmul popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3
$ ./cpuid2cpuflags -f make
CPU_FLAGS_X86="aes avx f16c mmx mmxext pclmul popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3"
$ ./cpuid2cpuflags -f plain
aes avx f16c mmx mmxext pclmul popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3
```
* Updated the README file and help message accordingly.
* Additionally, I've updated the README file with basic instructions on how to compile the program.

I'm open to feedback before merging.