### PR TITLE
ppc: add initial implementation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ cpuid2cpuflags_SOURCES = \
 	src/main.c \
 	src/platforms.h \
 	src/arm.c \
+	src/ppc.c \
 	src/x86.c \
 	src/x86-lib.c \
 	src/x86.h

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,9 @@
 /* arm.c */
 int print_arm();
 
+/* ppc.c */
+int print_ppc();
+
 struct option long_options[] = {
 	{ "help", no_argument, 0, 'h' },
 	{ "version", no_argument, 0, 'V' },
@@ -59,5 +62,8 @@ int main(int argc, char* argv[])
 #endif
 #ifdef CPUID_ARM
 	return print_arm();
+#endif
+#ifdef CPUID_PPC
+	return print_ppc();
 #endif
 }

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -9,6 +9,8 @@
 #		define CPUID_X86
 #	elif defined(__arm__) || defined(__aarch64__)
 #		define CPUID_ARM
+#	elif defined(__powerpc__)
+#		define CPUID_PPC
 #	else
 #		error "Unsupported platform, please report"
 #	endif

--- a/src/ppc.c
+++ b/src/ppc.c
@@ -22,7 +22,6 @@
 #ifdef HAVE_SYS_AUXV_H
 #	include <sys/auxv.h>
 #endif
-#include <sys/utsname.h>
 
 #ifndef __linux__
 #	error "Platform not supported (only Linux supported at the moment)"
@@ -48,7 +47,7 @@ struct check_desc
 struct flag_info
 {
 	const char* name;
-	struct check_desc checks[3];
+	struct check_desc checks[2];
 };
 
 struct flag_info flags[] = {
@@ -57,17 +56,14 @@ struct flag_info flags[] = {
 	{ "altivec", {{ CHECK_HWCAP, 0x10000000 }} },
 	/* PPC_FEATURE_HAS_VSX */
 	{ "vsx", {{ CHECK_HWCAP, 0x00000080 }} },
-	/* only ISA 3.00 CPU is P9, but it's possible to build a compliant
-	 * CPU that only implements the scalar instructions and not vsx */
-	/*  PPC_FEATURE_HAS_VSX | PPC_FEATURE2_ARCH_3_00 */
-	{ "vsx3", {{ CHECK_HWCAP, 0x00000080 }, { CHECK_HWCAP2, 0x00800000 }} },
+	/* PPC_FEATURE2_ARCH_3_00 */
+	{ "vsx3", {{ CHECK_HWCAP2, 0x00800000 }} },
 	{ 0 }
 };
 
 int print_ppc()
 {
 	unsigned long hwcap = 0, hwcap2 = 0;
-	struct utsname uname_res;
 	int i, j;
 
 	hwcap = getauxval(AT_HWCAP);

--- a/src/ppc.c
+++ b/src/ppc.c
@@ -1,0 +1,120 @@
+/* cpuid2cpuflags
+ * (c) 2015-2017 Michał Górny
+ * (c) 2019 Georgy Yakovlev
+ * (c) 2019 Shawn Anastasio
+ * 2-clause BSD licensed
+ */
+
+#ifdef HAVE_CONFIG_H
+#	include "config.h"
+#endif
+#include "platforms.h"
+
+#ifdef CPUID_PPC
+
+#include <stdio.h>
+#include <string.h>
+#ifdef HAVE_STDINT_H
+#	include <stdint.h>
+#endif
+#include <assert.h>
+
+#ifdef HAVE_SYS_AUXV_H
+#	include <sys/auxv.h>
+#endif
+#include <sys/utsname.h>
+
+#ifndef __linux__
+#	error "Platform not supported (only Linux supported at the moment)"
+#endif
+#ifndef HAVE_GETAUXVAL
+#	error "Platform not supported (no getauxval())"
+#endif
+
+enum check_type
+{
+	CHECK_SENTINEL = 0,
+	CHECK_HWCAP,
+	CHECK_HWCAP2,
+	CHECK_MAX
+};
+
+struct check_desc
+{
+	enum check_type type;
+	unsigned long mask;
+};
+
+struct flag_info
+{
+	const char* name;
+	struct check_desc checks[3];
+};
+
+struct flag_info flags[] = {
+	/* taken from /usr/include/bits/hwcap.h */
+	/* PPC_FEATURE_HAS_ALTIVEC */
+	{ "altivec", {{ CHECK_HWCAP, 0x10000000 }} },
+	/* PPC_FEATURE_HAS_VSX */
+	{ "vsx", {{ CHECK_HWCAP, 0x00000080 }} },
+	/* only ISA 3.00 CPU is P9, but it's possible to build a compliant
+	 * CPU that only implements the scalar instructions and not vsx */
+	/*  PPC_FEATURE_HAS_VSX | PPC_FEATURE2_ARCH_3_00 */
+	{ "vsx3", {{ CHECK_HWCAP, 0x00000080 }, { CHECK_HWCAP2, 0x00800000 }} },
+	{ 0 }
+};
+
+int print_ppc()
+{
+	unsigned long hwcap = 0, hwcap2 = 0;
+	struct utsname uname_res;
+	int i, j;
+
+	hwcap = getauxval(AT_HWCAP);
+	hwcap2 = getauxval(AT_HWCAP2);
+
+	fputs("CPU_FLAGS_PPC:", stdout);
+
+	for (i = 0; flags[i].name; ++i)
+	{
+		for (j = 0; flags[i].checks[j].type != 0; ++j)
+		{
+			int match = 0;
+			unsigned long* reg = 0;
+
+			switch (flags[i].checks[j].type)
+			{
+				case CHECK_HWCAP:
+						reg = &hwcap;
+					break;
+				case CHECK_HWCAP2:
+						reg = &hwcap2;
+					break;
+				case CHECK_SENTINEL:
+					assert(0 && "CHECK_SENTINEL reached");
+				case CHECK_MAX:
+					assert(0 && "CHECK_MAX reached");
+			}
+			assert(flags[i].checks[j].type <= CHECK_MAX);
+
+			if (reg)
+			{
+				if ((*reg & flags[i].checks[j].mask) == flags[i].checks[j].mask)
+					match = 1;
+			}
+
+			if (match)
+			{
+				fputc(' ', stdout);
+				fputs(flags[i].name, stdout);
+
+				break;
+			}
+		}
+	}
+
+	fputs("\n", stdout);
+	return 0;
+}
+
+#endif /*CPUID_PPC*/


### PR DESCRIPTION
add initial ppc support implementation, directly based on arm code

works on ppc and ppc64(be) and ppc64le

A lot of help received from Shawn, credited in commit message.

Flags do not exist yet in gentoo, but we plan to add those.

notable consumers where support already exists but not enabled or automagically determined: libpng, libvpx, ffmpeg, x264, x265, firefox-70 and other media libs, all get major speedup if built properly on modern power CPUs.