### PR TITLE
x86: Add support for 'rdrand'

### DIFF
--- a/src/x86.c
+++ b/src/x86.c
@@ -73,6 +73,7 @@ struct flag_info flags[] = {
 	{ "pclmul", INTEL_ECX, (1 << 1) },
 	{ "popcnt", INTEL_ECX, (1 << 23) }, /* Intel */
 	{ "popcnt", AMD_ECX, (1 << 5) }, /* ABM on AMD; XXX: manuals say it's LZCNT */
+	{ "rdrand", INTEL_ECX, (1 << 30) },
 	{ "sha", INTEL_SUB0_EBX, (1 << 29) },
 	{ "sse", INTEL_EDX, (1 << 25) },
 	{ "sse2", INTEL_EDX, (1 << 26) },

--- a/tests/x86/amd-colfax.txt
+++ b/tests/x86/amd-colfax.txt
@@ -1,4 +1,4 @@
-expected:aes avx avx2 f16c fma3 mmx mmxext pclmul popcnt sha sse sse2 sse3 sse4_1 sse4_2 sse4a ssse3
+expected:aes avx avx2 f16c fma3 mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 sse4a ssse3
 top:00000001:00800f82:0b400800:7ed8320b:178bfbff
 sub:00000007:00000000:00000000:209c01a9:00000000:00000000
 top:80000001:00800f82:70000000:35c233ff:2fd3fbff

--- a/tests/x86/xeon-e-2176g.txt
+++ b/tests/x86/xeon-e-2176g.txt
@@ -1,4 +1,4 @@
-expected:aes avx avx2 f16c fma3 mmx mmxext pclmul popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3
+expected:aes avx avx2 f16c fma3 mmx mmxext pclmul popcnt rdrand sse sse2 sse3 sse4_1 sse4_2 ssse3
 top:00000001:000906ea:07100800:7ffafbff:bfebfbff
 sub:00000007:00000000:00000000:029c6fbf:40000000:9c000000
 top:80000001:00000000:00000000:00000121:2c100800

--- a/tests/x86/xeon-silver-4410.txt
+++ b/tests/x86/xeon-silver-4410.txt
@@ -1,4 +1,4 @@
-expected:aes avx avx2 avx512f avx512dq avx512cd avx512bw avx512vl f16c fma3 mmx mmxext pclmul popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3
+expected:aes avx avx2 avx512f avx512dq avx512cd avx512bw avx512vl f16c fma3 mmx mmxext pclmul popcnt rdrand sse sse2 sse3 sse4_1 sse4_2 ssse3
 top:00000001:00050654:11100800:7ffefbff:bfebfbff
 sub:00000007:00000000:00000000:d39ffffb:00000018:9c002400
 top:80000001:00000000:00000000:00000121:2c100800


### PR DESCRIPTION
This should address #1 and #15 I am writting the rest of the patches to send to gentoo-dev as of now.