### PR TITLE
Add FreeBSD/arm{,64} support

### DIFF
--- a/src/hwcap.c
+++ b/src/hwcap.c
@@ -14,13 +14,19 @@
 #ifdef HAVE_SYS_AUXV_H
 #	include <sys/auxv.h>
 #endif
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#else
 #include <sys/utsname.h>
-
-#ifndef __linux__
-#	error "Platform not supported (only Linux supported at the moment)"
 #endif
+
 #ifndef HAVE_GETAUXVAL
-#	error "Platform not supported (no getauxval())"
+static unsigned long getauxval(int aux)
+{
+	unsigned long auxval = 0;
+	elf_aux_info(aux, &auxval, sizeof(auxval));
+	return auxval;
+}
 #endif
 
 #include "hwcap.h"
@@ -53,9 +59,23 @@ unsigned long get_hwcap2()
  */
 char* get_uname_machine()
 {
+#ifdef __FreeBSD__
+	/**
+	 * On FreeBSD, `uname -m' is too vague to distinguish between
+	 * particular CPUs, so we return more unique `uname -p' instead.
+	 * Because there is no `uname_res.machine_arch' field, we have
+	 * to call sysctl(3) rather than uname(3).
+	 */
+	int mib[] = { CTL_HW, HW_MACHINE_ARCH };
+	static char buf[48];
+	size_t len = sizeof(buf);
+	if (sysctl(mib, 2, &buf, &len, NULL, 0) == 0)
+		return buf;
+#else
 	static struct utsname uname_res;
 	if (uname(&uname_res) != -1)
 		return uname_res.machine;
+#endif
 	else
 		return NULL;
 }

--- a/src/hwcap.c
+++ b/src/hwcap.c
@@ -20,7 +20,7 @@
 #include <sys/utsname.h>
 #endif
 
-#ifndef HAVE_GETAUXVAL
+#ifdef __FreeBSD__
 static unsigned long getauxval(int aux)
 {
 	unsigned long auxval = 0;


### PR DESCRIPTION
- Replace `getauxval(3)`, a non-standard glibc extension, with FreeBSD's native `elf_aux_info(3)`
- Return features supported by the specific machine processor architecture rather than the hardware platform, because the latter is too vague on FreeBSD and does not include specific version (generation)