### PR TITLE
x86: Add support of vpclmulqdq and avx512 flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,6 +73,8 @@ TESTS = \
 	tests/x86/i3-ivybridge.txt \
 	tests/x86/opteron-6272.txt \
 	tests/x86/xeon-e-2176g.txt \
-	tests/x86/xeon-silver-4410.txt
+	tests/x86/xeon-silver-4410.txt \
+	tests/x86/amd-zen4.txt \
+	tests/x86/xeon-platinum-8480plus.txt
 
 EXTRA_DIST = $(TESTS) tests/test.sh

--- a/src/x86-dump.c
+++ b/src/x86-dump.c
@@ -60,6 +60,7 @@ int main(int argc, char* argv[])
 	dump(0x00000001);
 	/* Intel ext. */
 	dump_leaf(0x00000007, 0x00000000);
+	dump_leaf(0x00000007, 0x00000001);
 	/* AMD */
 	dump(0x80000001);
 	/* Centaur (VIA) */

--- a/src/x86.c
+++ b/src/x86.c
@@ -35,6 +35,8 @@ enum check_type
 	INTEL_EDX,
 	INTEL_SUB0_EBX,
 	INTEL_SUB0_ECX,
+	INTEL_SUB0_EDX,
+	INTEL_SUB1_EAX,
 	AMD_ECX,
 	AMD_EDX,
 	VIA_EDX,
@@ -55,11 +57,21 @@ struct flag_info flags[] = {
 	{ "aes", INTEL_ECX, (1 << 25) },
 	{ "avx", INTEL_ECX, (1 << 28) },
 	{ "avx2", INTEL_SUB0_EBX, (1 << 5) },
+	{ "avx512_4fmaps", INTEL_SUB0_EDX, (1 << 3) },
+	{ "avx512_4vnniw", INTEL_SUB0_EDX, (1 << 2) },
+	{ "avx512_bf16", INTEL_SUB1_EAX, (1 << 5) },
+	{ "avx512_bitalg", INTEL_SUB0_ECX, (1 << 12) },
+	{ "avx512_fp16", INTEL_SUB0_EDX, (1 << 23) },
+	{ "avx512_vbmi2", INTEL_SUB0_ECX, (1 << 6) },
+	{ "avx512_vnni", INTEL_SUB0_ECX, (1 << 11) },
+	{ "avx512_vp2intersect", INTEL_SUB0_EDX, (1 << 8) },
+	{ "avx512_vpopcntdq", INTEL_SUB0_ECX, (1 << 14) },
 	{ "avx512bw", INTEL_SUB0_EBX, (1 << 30) },
 	{ "avx512cd", INTEL_SUB0_EBX, (1 << 28) },
 	{ "avx512dq", INTEL_SUB0_EBX, (1 << 17) },
 	{ "avx512er", INTEL_SUB0_EBX, (1 << 27) },
 	{ "avx512f", INTEL_SUB0_EBX, (1 << 16) },
+	{ "avx512ifma", INTEL_SUB0_EBX, (1 << 21) },
 	{ "avx512pf", INTEL_SUB0_EBX, (1 << 26) },
 	{ "avx512vbmi", INTEL_SUB0_ECX, (1 << 1) },
 	{ "avx512vl", INTEL_SUB0_EBX, (1 << 31) },
@@ -82,6 +94,7 @@ struct flag_info flags[] = {
 	{ "sse4_2", INTEL_ECX, (1 << 20) },
 	{ "sse4a", AMD_ECX, (1 << 6) },
 	{ "ssse3", INTEL_ECX, (1 << 9) },
+	{ "vpclmulqdq", INTEL_SUB0_ECX, (1 << 10) },
 	{ "xop", AMD_ECX, (1 << 11) },
 	{ 0 }
 };
@@ -93,11 +106,12 @@ struct flag_info flags[] = {
  */
 int print_flags()
 {
-	uint32_t intel_ecx = 0, intel_edx = 0, intel_sub0_ebx = 0, intel_sub0_ecx = 0;
+	uint32_t intel_ecx = 0, intel_edx = 0;
+	uint32_t intel_sub0_ebx = 0, intel_sub0_ecx = 0, intel_sub0_edx = 0, intel_sub1_eax = 0;
 	uint32_t amd_ecx = 0, amd_edx = 0;
 	uint32_t centaur_edx = 0;
 
-	int got_intel, got_intel_sub0, got_amd, got_centaur;
+	int got_intel, got_intel_sub0, got_intel_sub1, got_amd, got_centaur;
 
 	const char* last = "";
 	int i;
@@ -105,7 +119,8 @@ int print_flags()
 	/* Intel */
 	got_intel = run_cpuid(0x00000001, 0, 0, &intel_ecx, &intel_edx);
 	/* Intel ext. */
-	got_intel_sub0 = run_cpuid_sub(0x00000007, 0x00000000, 0, &intel_sub0_ebx, &intel_sub0_ecx, 0);
+	got_intel_sub0 = run_cpuid_sub(0x00000007, 0x00000000, 0, &intel_sub0_ebx, &intel_sub0_ecx, &intel_sub0_edx);
+	got_intel_sub1 = run_cpuid_sub(0x00000007, 0x00000001, &intel_sub1_eax, 0, 0, 0);
 	/* AMD */
 	got_amd = run_cpuid(0x80000001, 0, 0, &amd_ecx, &amd_edx);
 	/* Centaur (VIA) */
@@ -134,6 +149,14 @@ int print_flags()
 			case INTEL_SUB0_ECX:
 				if (got_intel_sub0)
 					reg = &intel_sub0_ecx;
+				break;
+			case INTEL_SUB0_EDX:
+				if (got_intel_sub0)
+					reg = &intel_sub0_edx;
+				break;
+			case INTEL_SUB1_EAX:
+				if (got_intel_sub1)
+					reg = &intel_sub1_eax;
 				break;
 			case AMD_ECX:
 				if (got_amd)

--- a/src/x86.c
+++ b/src/x86.c
@@ -55,24 +55,24 @@ struct flag_info flags[] = {
 	{ "aes", INTEL_ECX, (1 << 25) },
 	{ "avx", INTEL_ECX, (1 << 28) },
 	{ "avx2", INTEL_SUB0_EBX, (1 << 5) },
-	{ "avx512f", INTEL_SUB0_EBX, (1 << 16) },
-	{ "avx512dq", INTEL_SUB0_EBX, (1 << 17) },
-	{ "avx512pf", INTEL_SUB0_EBX, (1 << 26) },
-	{ "avx512er", INTEL_SUB0_EBX, (1 << 27) },
-	{ "avx512cd", INTEL_SUB0_EBX, (1 << 28) },
 	{ "avx512bw", INTEL_SUB0_EBX, (1 << 30) },
-	{ "avx512vl", INTEL_SUB0_EBX, (1 << 31) },
+	{ "avx512cd", INTEL_SUB0_EBX, (1 << 28) },
+	{ "avx512dq", INTEL_SUB0_EBX, (1 << 17) },
+	{ "avx512er", INTEL_SUB0_EBX, (1 << 27) },
+	{ "avx512f", INTEL_SUB0_EBX, (1 << 16) },
+	{ "avx512pf", INTEL_SUB0_EBX, (1 << 26) },
 	{ "avx512vbmi", INTEL_SUB0_ECX, (1 << 1) },
+	{ "avx512vl", INTEL_SUB0_EBX, (1 << 31) },
 	{ "f16c", INTEL_ECX, (1 << 29) },
 	{ "fma3", INTEL_ECX, (1 << 12) },
 	{ "fma4", AMD_ECX, (1 << 16) },
 	{ "mmx", INTEL_EDX, (1 << 23) },
-	{ "mmxext", INTEL_EDX, (1 << 25) }, /* implied by SSE on Intel */
 	{ "mmxext", AMD_EDX, (1 << 22) }, /* AMD */
+	{ "mmxext", INTEL_EDX, (1 << 25) }, /* implied by SSE on Intel */
 	{ "padlock", VIA_EDX, (1 << 10) }, /* PHE */
 	{ "pclmul", INTEL_ECX, (1 << 1) },
-	{ "popcnt", INTEL_ECX, (1 << 23) }, /* Intel */
 	{ "popcnt", AMD_ECX, (1 << 5) }, /* ABM on AMD; XXX: manuals say it's LZCNT */
+	{ "popcnt", INTEL_ECX, (1 << 23) }, /* Intel */
 	{ "rdrand", INTEL_ECX, (1 << 30) },
 	{ "sha", INTEL_SUB0_EBX, (1 << 29) },
 	{ "sse", INTEL_EDX, (1 << 25) },

--- a/tests/x86/amd-zen4.txt
+++ b/tests/x86/amd-zen4.txt
@@ -1,0 +1,5 @@
+expected:aes avx avx2 avx512_bf16 avx512_bitalg avx512_vbmi2 avx512_vnni avx512_vpopcntdq avx512bw avx512cd avx512dq avx512f avx512ifma avx512vbmi avx512vl f16c fma3 mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 sse4a ssse3 vpclmulqdq
+top:00000001:00a60f12:1f200800:7ef8320b:178bfbff
+sub:00000007:00000000:00000001:f1bf97a9:00405fde:10000010
+sub:00000007:00000001:00000020:00000000:00000000:00000000
+top:80000001:00a60f12:00000000:75c237ff:2fd3fbff

--- a/tests/x86/xeon-platinum-8480plus.txt
+++ b/tests/x86/xeon-platinum-8480plus.txt
@@ -1,0 +1,5 @@
+expected:aes avx avx2 avx512_bf16 avx512_bitalg avx512_fp16 avx512_vbmi2 avx512_vnni avx512_vpopcntdq avx512bw avx512cd avx512dq avx512f avx512ifma avx512vbmi avx512vl f16c fma3 mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 ssse3 vpclmulqdq
+top:00000001:000806f8:8b800800:7ffefbff:bfebfbff
+sub:00000007:00000000:00000002:f3bfb7ef:fb417ffe:ffdd4432
+sub:00000007:00000001:00001c30:00000000:00000000:00040000
+top:80000001:00000000:00000000:00000121:2c100800

--- a/tests/x86/xeon-silver-4410.txt
+++ b/tests/x86/xeon-silver-4410.txt
@@ -1,4 +1,4 @@
-expected:aes avx avx2 avx512f avx512dq avx512cd avx512bw avx512vl f16c fma3 mmx mmxext pclmul popcnt rdrand sse sse2 sse3 sse4_1 sse4_2 ssse3
+expected:aes avx avx2 avx512bw avx512cd avx512dq avx512f avx512vl f16c fma3 mmx mmxext pclmul popcnt rdrand sse sse2 sse3 sse4_1 sse4_2 ssse3
 top:00000001:00050654:11100800:7ffefbff:bfebfbff
 sub:00000007:00000000:00000000:d39ffffb:00000018:9c002400
 top:80000001:00000000:00000000:00000121:2c100800


### PR DESCRIPTION
This PR sorts existing flags alphabetically and adds support of AVX-512 flags (completing table https://en.wikichip.org/wiki/x86/avx512_vnni#Microarchitecture_support) and vpclmulqdq.

Names for flags are reused from /proc/cpuinfo.

Test results:

| CPU     | `/proc/cpuinfo` flags | `cpuid2cpuflags` |
| ---      | ---       | ---       |
| AMD Ryzen 9 7950X3D 16-Core Processor | `fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good amd_lbr_v2 nopl nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba perfmon_v2 ibrs ibpb stibp ibrs_enhanced vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk avx512_bf16 clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif x2avic v_spec_ctrl vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid overflow_recov succor smca fsrm flush_l1d` | `CPU_FLAGS_X86: aes avx avx2 avx512bw avx512cd avx512dq avx512f avx512vbmi avx512vl f16c fma3 avx512_vbmi2 vpclmulqdq avx512_vnni avx512ifma avx512_bitalg avx512_vpopcntdq avx512_bf16 mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 sse4a ssse3` |
| Intel(R) Xeon(R) Platinum 8480+ | `fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cat_l2 cdp_l3 invpcid_single intel_ppin cdp_l2 ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local split_lock_detect avx_vnni avx512_bf16 wbnoinvd dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req avx512vbmi umip pku ospke waitpkg avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg tme avx512_vpopcntdq la57 rdpid bus_lock_detect cldemote movdiri movdir64b enqcmd fsrm md_clear serialize tsxldtrk pconfig arch_lbr amx_bf16 avx512_fp16 amx_tile amx_int8 flush_l1d arch_capabilities` | `CPU_FLAGS_X86: aes avx avx2 avx512bw avx512cd avx512dq avx512f avx512vbmi avx512vl f16c fma3 avx512_vbmi2 vpclmulqdq avx512_vnni avx512_fp16 avx512ifma avx512_bitalg avx512_vpopcntdq avx512_bf16 mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 ssse3` |

Bug: https://bugs.gentoo.org/908556