### PR TITLE
arm: add aarch64_be subarch

### DIFF
--- a/src/arm.c
+++ b/src/arm.c
@@ -55,6 +55,7 @@ struct subarch_info subarches[] = {
 	/* grep -Rho string.*cpu_arch_name.*$ arch/arm | sort -u */
 	/* start with newest as the most likely */
 	{ "aarch64", SUBARCH_AARCH64 },
+	{ "aarch64_be", SUBARCH_AARCH64 },
 	{ "armv8", SUBARCH_V8 },
 	{ "armv7", SUBARCH_V7 },
 	{ "armv6", SUBARCH_V6 },


### PR DESCRIPTION
It is not a popular flavor, but still Gentoo builds the stages for it. Just adding it as another arm subarch works.
Verified on a KVM VM with host passthrough CPU using AArch64 BE Gentoo kernel and rootfs.